### PR TITLE
Add user logged in variable to getPortfolioItems

### DIFF
--- a/src/blockchain/xaave/portfolio.ts
+++ b/src/blockchain/xaave/portfolio.ts
@@ -12,7 +12,8 @@ import { getXAavePrices } from './prices'
 export const getPortfolioItemXAave = async (
   symbol: ITokenSymbols,
   address: string,
-  provider: JsonRpcProvider
+  provider: JsonRpcProvider,
+  loggedIn: boolean
 ) => {
   const {
     kyberProxyContract,
@@ -21,7 +22,12 @@ export const getPortfolioItemXAave = async (
   } = await getXAaveContracts(symbol, provider)
   const { chainId } = network
 
-  const xaaveBal = await getUserAvailableTokenBalance(xaaveContract, address)
+  let xaaveBal
+  if (loggedIn) {
+    xaaveBal = await getUserAvailableTokenBalance(xaaveContract, address)
+  } else {
+    xaaveBal = 0
+  }
 
   const { priceUsd } = await getXAavePrices(
     xaaveContract,

--- a/src/blockchain/xaave/portfolio.ts
+++ b/src/blockchain/xaave/portfolio.ts
@@ -13,7 +13,7 @@ export const getPortfolioItemXAave = async (
   symbol: ITokenSymbols,
   address: string,
   provider: JsonRpcProvider,
-  loggedIn: boolean
+  isLoggedIn: boolean
 ) => {
   const {
     kyberProxyContract,
@@ -22,12 +22,9 @@ export const getPortfolioItemXAave = async (
   } = await getXAaveContracts(symbol, provider)
   const { chainId } = network
 
-  let xaaveBal
-  if (loggedIn) {
-    xaaveBal = await getUserAvailableTokenBalance(xaaveContract, address)
-  } else {
-    xaaveBal = 0
-  }
+  const xaaveBal = isLoggedIn
+    ? await getUserAvailableTokenBalance(xaaveContract, address)
+    : 0
 
   const { priceUsd } = await getXAavePrices(
     xaaveContract,

--- a/src/blockchain/xknc/portfolio.ts
+++ b/src/blockchain/xknc/portfolio.ts
@@ -1,7 +1,8 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { Contract } from 'ethers'
+import { KNC } from 'xtoken-abis'
 
-import { DEC_18, KNC } from '../../constants'
+import { DEC_18 } from '../../constants'
 import { XKNC } from '../../types'
 import { ITokenSymbols } from '../../types/xToken'
 import { formatNumberWithCommas } from '../../utils'
@@ -14,7 +15,7 @@ export const getPortfolioItemXKnc = async (
   symbol: ITokenSymbols,
   address: string,
   provider: JsonRpcProvider,
-  loggedIn: boolean
+  isLoggedIn: boolean
 ) => {
   const { kyberProxyContract, network, xkncContract } = await getXKncContracts(
     symbol,
@@ -22,12 +23,9 @@ export const getPortfolioItemXKnc = async (
   )
   const { chainId } = network
 
-  let xkncBal: number
-  if (loggedIn) {
-    xkncBal = await getUserAvailableTokenBalance(xkncContract, address)
-  } else {
-    xkncBal = 0
-  }
+  const xkncBal = isLoggedIn
+    ? await getUserAvailableTokenBalance(xkncContract, address)
+    : 0
   const kncContract = getContract(KNC, provider, network)
 
   const { priceUsd } = await getXKncPrices(

--- a/src/blockchain/xknc/portfolio.ts
+++ b/src/blockchain/xknc/portfolio.ts
@@ -13,7 +13,8 @@ import { getXKncPrices } from './prices'
 export const getPortfolioItemXKnc = async (
   symbol: ITokenSymbols,
   address: string,
-  provider: JsonRpcProvider
+  provider: JsonRpcProvider,
+  loggedIn: boolean
 ) => {
   const { kyberProxyContract, network, xkncContract } = await getXKncContracts(
     symbol,
@@ -21,7 +22,12 @@ export const getPortfolioItemXKnc = async (
   )
   const { chainId } = network
 
-  const xkncBal = await getUserAvailableTokenBalance(xkncContract, address)
+  let xkncBal: number
+  if (loggedIn) {
+    xkncBal = await getUserAvailableTokenBalance(xkncContract, address)
+  } else {
+    xkncBal = 0
+  }
   const kncContract = getContract(KNC, provider, network)
 
   const { priceUsd } = await getXKncPrices(

--- a/src/blockchain/xsnx/portfolio.ts
+++ b/src/blockchain/xsnx/portfolio.ts
@@ -20,7 +20,8 @@ import { getXSnxPrices } from './prices'
 export const getPortfolioItemXSnx = async (
   symbol: ITokenSymbols,
   address: string,
-  provider: JsonRpcProvider
+  provider: JsonRpcProvider,
+  loggedIn: boolean
 ) => {
   const {
     network,
@@ -35,7 +36,14 @@ export const getPortfolioItemXSnx = async (
 
   const exchangeRatesContract = await getExchangeRateContract(provider)
   const snxContract = getContract(SNX, provider, network)
-  const xsnxBal = await getUserAvailableTokenBalance(xsnxContract, address)
+
+  let xsnxBal: number
+  if (loggedIn) {
+    xsnxBal = await getUserAvailableTokenBalance(xsnxContract, address)
+  } else {
+    xsnxBal = 0
+  }
+
   const xsnxBalRaw = await getTokenBalance(
     xsnxContract.address,
     address,

--- a/src/blockchain/xsnx/portfolio.ts
+++ b/src/blockchain/xsnx/portfolio.ts
@@ -1,8 +1,8 @@
 import { JsonRpcProvider } from '@ethersproject/providers'
 import { Contract } from 'ethers'
+import { ADDRESSES, SNX, X_SNX_A_ADMIN } from 'xtoken-abis'
 
-import ADDRESSES from '../../addresses'
-import { DEC_18, SNX, X_SNX_A_ADMIN } from '../../constants'
+import { DEC_18 } from '../../constants'
 import { ExchangeRates } from '../../types'
 import { ITokenSymbols } from '../../types/xToken'
 import { formatNumber, formatNumberWithCommas } from '../../utils'
@@ -21,7 +21,7 @@ export const getPortfolioItemXSnx = async (
   symbol: ITokenSymbols,
   address: string,
   provider: JsonRpcProvider,
-  loggedIn: boolean
+  isLoggedIn: boolean
 ) => {
   const {
     network,
@@ -36,14 +36,9 @@ export const getPortfolioItemXSnx = async (
 
   const exchangeRatesContract = await getExchangeRateContract(provider)
   const snxContract = getContract(SNX, provider, network)
-
-  let xsnxBal: number
-  if (loggedIn) {
-    xsnxBal = await getUserAvailableTokenBalance(xsnxContract, address)
-  } else {
-    xsnxBal = 0
-  }
-
+  const xsnxBal = isLoggedIn
+    ? await getUserAvailableTokenBalance(xsnxContract, address)
+    : 0
   const xsnxBalRaw = await getTokenBalance(
     xsnxContract.address,
     address,

--- a/src/xToken.ts
+++ b/src/xToken.ts
@@ -152,16 +152,16 @@ export class XToken {
     }
   }
 
-  public async getPortfolioItems() {
+  public async getPortfolioItems(loggedIn: boolean) {
     const signer = this.provider.getSigner()
     const address = await signer.getAddress()
 
     return Promise.all([
-      getPortfolioItemXKnc(X_KNC_A, address, this.provider),
-      getPortfolioItemXKnc(X_KNC_B, address, this.provider),
-      getPortfolioItemXSnx(X_SNX_A, address, this.provider),
-      getPortfolioItemXAave(X_AAVE_A, address, this.provider),
-      getPortfolioItemXAave(X_AAVE_B, address, this.provider),
+      getPortfolioItemXKnc(X_KNC_A, address, this.provider, loggedIn),
+      getPortfolioItemXKnc(X_KNC_B, address, this.provider, loggedIn),
+      getPortfolioItemXSnx(X_SNX_A, address, this.provider, loggedIn),
+      getPortfolioItemXAave(X_AAVE_A, address, this.provider, loggedIn),
+      getPortfolioItemXAave(X_AAVE_B, address, this.provider, loggedIn),
     ])
   }
 

--- a/src/xToken.ts
+++ b/src/xToken.ts
@@ -152,16 +152,16 @@ export class XToken {
     }
   }
 
-  public async getPortfolioItems(loggedIn: boolean) {
+  public async getPortfolioItems(isLoggedIn: boolean) {
     const signer = this.provider.getSigner()
     const address = await signer.getAddress()
 
     return Promise.all([
-      getPortfolioItemXKnc(X_KNC_A, address, this.provider, loggedIn),
-      getPortfolioItemXKnc(X_KNC_B, address, this.provider, loggedIn),
-      getPortfolioItemXSnx(X_SNX_A, address, this.provider, loggedIn),
-      getPortfolioItemXAave(X_AAVE_A, address, this.provider, loggedIn),
-      getPortfolioItemXAave(X_AAVE_B, address, this.provider, loggedIn),
+      getPortfolioItemXKnc(X_KNC_A, address, this.provider, isLoggedIn),
+      getPortfolioItemXKnc(X_KNC_B, address, this.provider, isLoggedIn),
+      getPortfolioItemXSnx(X_SNX_A, address, this.provider, isLoggedIn),
+      getPortfolioItemXAave(X_AAVE_A, address, this.provider, isLoggedIn),
+      getPortfolioItemXAave(X_AAVE_B, address, this.provider, isLoggedIn),
     ])
   }
 


### PR DESCRIPTION
This feature adds an `isLoggedIn` parameter to `getPortfolioItems` that is passed to each subsequent `xToken` API call in order to cut down on unnecessary async calls.
