### PR TITLE
Reverted to Kyber for xKNC token prices

### DIFF
--- a/src/blockchain/exchanges/balancer.ts
+++ b/src/blockchain/exchanges/balancer.ts
@@ -21,7 +21,7 @@ import {
   X_SNX_A_BALANCER_POOL,
 } from 'xtoken-abis'
 
-import { DEC_18 } from '../../constants'
+import { DEC_18, Exchange } from '../../constants'
 import {
   BalancerPool,
   ExchangeRates,
@@ -164,6 +164,7 @@ const getBalances = async (
   const xTokenBalance = await xTokenContract.balanceOf(balancerPoolAddress)
 
   const ethPrice = await getExpectedRate(
+    Exchange.INCH,
     kyberProxyContract,
     ethAddress,
     usdcAddress,
@@ -257,6 +258,7 @@ export const getBalancerPortfolioItem = async (
       )
       tokenPrice = priceUsd
       underlyingPrice = await getExpectedRate(
+        Exchange.INCH,
         kyberProxyContract,
         underlyingAddress, // SNX
         usdcAddress,
@@ -273,6 +275,7 @@ export const getBalancerPortfolioItem = async (
       )
       tokenPrice = priceUsd
       underlyingPrice = await getExpectedRate(
+        Exchange.INCH,
         kyberProxyContract,
         underlyingAddress, // AAVE
         usdcAddress,
@@ -290,6 +293,7 @@ export const getBalancerPortfolioItem = async (
       tokenPrice = priceUsd
 
       underlyingPrice = await getExpectedRate(
+        Exchange.INCH,
         kyberProxyContract,
         underlyingAddress, // AAVE
         usdcAddress,

--- a/src/blockchain/exchanges/inch.ts
+++ b/src/blockchain/exchanges/inch.ts
@@ -10,7 +10,7 @@ import {
   X_INCH_B,
 } from 'xtoken-abis'
 
-import { DEC_18 } from '../../constants'
+import { DEC_18, Exchange } from '../../constants'
 import { InchLiquidityProtocol, KyberProxy, XINCH } from '../../types'
 import { ILiquidityPoolItem, ITokenSymbols } from '../../types/xToken'
 import {
@@ -43,6 +43,7 @@ const getBalances = async (
   const xTokenBalance = await xTokenContract.balanceOf(inchPoolAddress)
 
   const ethPrice = await getExpectedRate(
+    Exchange.INCH,
     kyberProxyContract,
     ethAddress,
     usdcAddress,

--- a/src/blockchain/utils.spec.ts
+++ b/src/blockchain/utils.spec.ts
@@ -9,6 +9,7 @@ import {
   X_KNC_A,
 } from 'xtoken-abis'
 
+import { Exchange } from '../constants'
 import { provider } from '../constants.spec'
 
 import { getBalancerPoolAddress, getExpectedRate } from './utils'
@@ -31,6 +32,7 @@ test('Expected rate for xAAVEa', async (t) => {
   )
   const expectedRate = formatEther(
     await getExpectedRate(
+      Exchange.INCH,
       kyberProxyContract,
       tokenContract.address,
       ADDRESSES[ETH] as string,

--- a/src/blockchain/xaave/burn.ts
+++ b/src/blockchain/xaave/burn.ts
@@ -4,7 +4,7 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import { ethers } from 'ethers'
 import { AAVE, ADDRESSES, ETH } from 'xtoken-abis'
 
-import { DEC_18 } from '../../constants'
+import { DEC_18, Exchange } from '../../constants'
 import { XAAVE } from '../../types'
 import { ITokenSymbols } from '../../types/xToken'
 import { getExpectedRate, parseFees } from '../utils'
@@ -28,6 +28,7 @@ export const burnXAave = async (
   const { proRataAave } = await getProRataAave(xaaveContract, amount)
 
   const minRate = await getExpectedRate(
+    Exchange.INCH,
     kyberProxyContract,
     tokenContract.address,
     ADDRESSES[ETH] as string,
@@ -65,6 +66,7 @@ export const getExpectedQuantityOnBurnXAave = async (
     const aaveAddress = ADDRESSES[AAVE][chainId]
 
     const expectedRate = await getExpectedRate(
+      Exchange.INCH,
       kyberProxyContract,
       aaveAddress,
       ethAddress,

--- a/src/blockchain/xaave/mint.ts
+++ b/src/blockchain/xaave/mint.ts
@@ -4,7 +4,7 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import { ethers } from 'ethers'
 import { AAVE, ADDRESSES, ETH } from 'xtoken-abis'
 
-import { DEC_18 } from '../../constants'
+import { DEC_18, Exchange } from '../../constants'
 import { XAAVE } from '../../types'
 import { ITokenSymbols } from '../../types/xToken'
 import { getExpectedRate, parseFees } from '../utils'
@@ -55,6 +55,7 @@ export const getExpectedQuantityOnMintXAave = async (
 
   if (tradeWithEth) {
     const expectedRate = await getExpectedRate(
+      Exchange.INCH,
       kyberProxyContract,
       ethAddress,
       aaveAddress,
@@ -87,6 +88,7 @@ export const mintXAave = async (
 
   if (tradeWithEth) {
     const minRate = await getExpectedRate(
+      Exchange.INCH,
       kyberProxyContract,
       ADDRESSES[ETH] as string,
       tokenContract.address,

--- a/src/blockchain/xaave/prices.ts
+++ b/src/blockchain/xaave/prices.ts
@@ -1,7 +1,7 @@
 import { formatEther, parseEther } from 'ethers/lib/utils'
 import { AAVE, ADDRESSES, ETH, USDC } from 'xtoken-abis'
 
-import { DEC_18 } from '../../constants'
+import { DEC_18, Exchange } from '../../constants'
 import { KyberProxy, XAAVE } from '../../types'
 import { ITokenPrices } from '../../types/xToken'
 import { formatNumber } from '../../utils'
@@ -60,8 +60,20 @@ export const getXAavePrices = async (
   ] = await Promise.all([
     xaaveContract.totalSupply(),
     xaaveContract.getFundHoldings(),
-    getExpectedRate(kyberProxyContract, aaveAddress, usdcAddress, proxyValue),
-    getExpectedRate(kyberProxyContract, ethAddress, usdcAddress, proxyValue),
+    getExpectedRate(
+      Exchange.INCH,
+      kyberProxyContract,
+      aaveAddress,
+      usdcAddress,
+      proxyValue
+    ),
+    getExpectedRate(
+      Exchange.INCH,
+      kyberProxyContract,
+      ethAddress,
+      usdcAddress,
+      proxyValue
+    ),
   ])
 
   const xaavePerToken = xaaveAaveBal.mul(DEC_18).div(xaaveTotalSupply)

--- a/src/blockchain/xinch/prices.ts
+++ b/src/blockchain/xinch/prices.ts
@@ -1,7 +1,7 @@
 import { formatEther, parseEther } from 'ethers/lib/utils'
 import { ADDRESSES, ETH, INCH, USDC } from 'xtoken-abis'
 
-import { DEC_18 } from '../../constants'
+import { DEC_18, Exchange } from '../../constants'
 import { KyberProxy, XINCH } from '../../types'
 import { ITokenPrices } from '../../types/xToken'
 import { formatNumber } from '../../utils'
@@ -60,8 +60,20 @@ export const getXInchPrices = async (
   ] = await Promise.all([
     xinchContract.totalSupply(),
     xinchContract.getNav(),
-    getExpectedRate(kyberProxyContract, inchAddress, usdcAddress, proxyValue),
-    getExpectedRate(kyberProxyContract, ethAddress, usdcAddress, proxyValue),
+    getExpectedRate(
+      Exchange.INCH,
+      kyberProxyContract,
+      inchAddress,
+      usdcAddress,
+      proxyValue
+    ),
+    getExpectedRate(
+      Exchange.INCH,
+      kyberProxyContract,
+      ethAddress,
+      usdcAddress,
+      proxyValue
+    ),
   ])
 
   const inchPerToken = inchHoldings.mul(DEC_18).div(xinchTotalSupply)

--- a/src/blockchain/xknc/burn.ts
+++ b/src/blockchain/xknc/burn.ts
@@ -4,7 +4,7 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import { ethers } from 'ethers'
 import { ADDRESSES, ETH, KNC } from 'xtoken-abis'
 
-import { DEC_18 } from '../../constants'
+import { DEC_18, Exchange } from '../../constants'
 import { ITokenSymbols } from '../../types/xToken'
 import { getExpectedRate, parseFees } from '../utils'
 
@@ -25,6 +25,7 @@ export const burnXKnc = async (
   } = await getXKncContracts(symbol, provider)
 
   const minRate = await getExpectedRate(
+    Exchange.KYBER,
     kyberProxyContract,
     tokenContract.address,
     ADDRESSES[ETH] as string,
@@ -65,6 +66,7 @@ export const getExpectedQuantityOnBurnXKnc = async (
     const kncAddress = ADDRESSES[KNC][chainId]
 
     const expectedRate = await getExpectedRate(
+      Exchange.KYBER,
       kyberProxyContract,
       kncAddress,
       ethAddress,

--- a/src/blockchain/xknc/mint.ts
+++ b/src/blockchain/xknc/mint.ts
@@ -4,7 +4,7 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import { ethers } from 'ethers'
 import { ADDRESSES, ETH, KNC } from 'xtoken-abis'
 
-import { DEC_18 } from '../../constants'
+import { DEC_18, Exchange } from '../../constants'
 import { XKNC } from '../../types'
 import { ITokenSymbols } from '../../types/xToken'
 import { getExpectedRate, parseFees } from '../utils'
@@ -54,6 +54,7 @@ export const getExpectedQuantityOnMintXKnc = async (
 
   if (tradeWithEth) {
     const expectedRate = await getExpectedRate(
+      Exchange.KYBER,
       kyberProxyContract,
       ethAddress,
       kncAddress,
@@ -87,6 +88,7 @@ export const mintXKnc = async (
 
   if (tradeWithEth) {
     const minRate = await getExpectedRate(
+      Exchange.KYBER,
       kyberProxyContract,
       ADDRESSES[ETH] as string,
       tokenContract.address,

--- a/src/blockchain/xknc/prices.ts
+++ b/src/blockchain/xknc/prices.ts
@@ -2,7 +2,7 @@ import { Contract } from 'ethers'
 import { formatEther, parseEther } from 'ethers/lib/utils'
 import { ADDRESSES, ETH, USDC } from 'xtoken-abis'
 
-import { DEC_18 } from '../../constants'
+import { DEC_18, Exchange } from '../../constants'
 import { KyberProxy, XKNC } from '../../types'
 import { ITokenPrices } from '../../types/xToken'
 import { formatNumber } from '../../utils'
@@ -65,12 +65,19 @@ export const getXKncPrices = async (
     xkncContract.totalSupply(),
     xkncContract.getFundKncBalanceTwei(),
     getExpectedRate(
+      Exchange.KYBER,
       kyberProxyContract,
       kncContract.address,
       usdcAddress,
       proxyValue
     ),
-    getExpectedRate(kyberProxyContract, ethAddress, usdcAddress, proxyValue),
+    getExpectedRate(
+      Exchange.INCH,
+      kyberProxyContract,
+      ethAddress,
+      usdcAddress,
+      proxyValue
+    ),
   ])
 
   const priceUsd = xkncKncBal.mul(kncUsdRate).div(xkncTotalSupply)

--- a/src/blockchain/xsnx/mint.ts
+++ b/src/blockchain/xsnx/mint.ts
@@ -3,7 +3,7 @@ import { JsonRpcProvider } from '@ethersproject/providers'
 import { BigNumber, ethers } from 'ethers'
 import { ADDRESSES, ETH, SNX } from 'xtoken-abis'
 
-import { DEC_18 } from '../../constants'
+import { DEC_18, Exchange } from '../../constants'
 import { XSNX } from '../../types'
 import { getExpectedRate, parseFees } from '../utils'
 
@@ -44,6 +44,7 @@ export const getExpectedQuantityOnMintXSnx = async (
   if (tradeWithEth) {
     const ethContributed = inputAmount.mul(MINT_FEE).div(DEC_18)
     const expectedRate = await getExpectedRate(
+      Exchange.INCH,
       kyberProxyContract,
       ADDRESSES[ETH] as string,
       ADDRESSES[SNX][chainId],
@@ -90,6 +91,7 @@ export const mintXSnx = async (
 
   if (tradeWithEth) {
     const minRate = await getExpectedRate(
+      Exchange.INCH,
       kyberProxyContract,
       ADDRESSES[ETH] as string,
       tokenContract.address,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,12 @@ export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 // 1Inch
 export const INCH_API_URL = 'https://api.1inch.exchange/v2.0/quote'
+
+// DEX
+export enum Exchange {
+  BALANCER = 'Balancer',
+  INCH = '1Inch',
+  KYBER = 'Kyber',
+  UNISWAP = 'Uniswap',
+  XTOKEN = 'xToken',
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Reverted to `Kyber` for `xKNC` token prices as `1Inch` is having issues
