### PR TITLE
Fixed wrong flag usage to burn xKNC

### DIFF
--- a/src/blockchain/xknc/burn.ts
+++ b/src/blockchain/xknc/burn.ts
@@ -32,7 +32,8 @@ export const burnXKnc = async (
     true
   )
 
-  return xkncContract.burn(amount, sellForEth, minRate)
+  // `xKNC` contract has `redeemForKnc` instead of `sellForEth` bool
+  return xkncContract.burn(amount, !sellForEth, minRate)
 }
 
 export const getExpectedQuantityOnBurnXKnc = async (


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Fixed the wrong usage of `sellForEth` flag instead of `redeemForKnc` when burning `xKNC`
