### PR TITLE
Added helper method to estimate returns for xKNC Uniswap pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,11 +84,11 @@
     "typechain": "^4.0.1",
     "typedoc": "^0.20.24",
     "typescript": "^4.1.5",
-    "xtoken-abis": "0.1.7"
+    "xtoken-abis": "0.1.8"
   },
   "peerDependencies": {
     "ethers": "5.0.30",
-    "xtoken-abis": "0.1.7"
+    "xtoken-abis": "0.1.8"
   },
   "files": [
     "build/main",

--- a/src/blockchain/exchanges/uniswap.spec.ts
+++ b/src/blockchain/exchanges/uniswap.spec.ts
@@ -1,14 +1,90 @@
 import test from 'ava'
-import { X_KNC_A, X_KNC_B } from 'xtoken-abis'
+import { BUY, ETH, SELL, X_KNC_A, X_KNC_B } from 'xtoken-abis'
 
 import { provider, testAddress } from '../../constants.spec'
 
-import { getEthUsdcPrice, getUniswapPortfolioItem } from './uniswap'
+import {
+  getEthUsdcPrice,
+  getUniswapEstimatedQuantity,
+  getUniswapPortfolioItem,
+} from './uniswap'
 
 test('Get ETH<>USDC rate', async (t) => {
   const ethUsdcRate = await getEthUsdcPrice(provider)
   console.log('[Uniswap] ETH<>USDC rate:', ethUsdcRate)
   t.true(Number(ethUsdcRate) > 0)
+})
+
+test('Calculate expected quantity on burn of xKNCa on Uniswap', async (t) => {
+  const expectedQty = await getUniswapEstimatedQuantity(
+    ETH,
+    X_KNC_A,
+    '1000',
+    SELL,
+    provider
+  )
+  console.log('[Uniswap] Expected ETH qty for 1000 xKNCa:', expectedQty)
+  t.true(Number(expectedQty) > 0)
+})
+
+test('Calculate expected quantity on burn of xKNCa with KNC on Uniswap', async (t) => {
+  const expectedQty = await getUniswapEstimatedQuantity(
+    X_KNC_A,
+    X_KNC_A,
+    '1000',
+    SELL,
+    provider
+  )
+  console.log('[Uniswap] Expected KNC qty for 1000 xKNCa:', expectedQty)
+  t.true(Number(expectedQty) > 0)
+})
+
+test('Calculate expected quantity on mint of xKNCa on Uniswap', async (t) => {
+  const expectedQty = await getUniswapEstimatedQuantity(
+    ETH,
+    X_KNC_A,
+    '1',
+    BUY,
+    provider
+  )
+  console.log('[Uniswap] Expected xKNCa qty for 1 ETH:', expectedQty)
+  t.true(Number(expectedQty) > 0)
+})
+
+test('Calculate expected quantity on mint of xKNCa with KNC on Uniswap', async (t) => {
+  const expectedQty = await getUniswapEstimatedQuantity(
+    X_KNC_A,
+    X_KNC_A,
+    '100',
+    BUY,
+    provider
+  )
+  console.log('[Uniswap] Expected xKNCa qty for 100 KNC:', expectedQty)
+  t.true(Number(expectedQty) > 0)
+})
+
+test('Calculate expected quantity on mint of xKNCb on Uniswap', async (t) => {
+  const expectedQty = await getUniswapEstimatedQuantity(
+    ETH,
+    X_KNC_B,
+    '1',
+    BUY,
+    provider
+  )
+  console.log('[Uniswap] Expected xKNCb qty for 1 ETH:', expectedQty)
+  t.true(Number(expectedQty) > 0)
+})
+
+test('Calculate expected quantity on mint of xKNCb with KNC on Uniswap', async (t) => {
+  const expectedQty = await getUniswapEstimatedQuantity(
+    X_KNC_B,
+    X_KNC_B,
+    '100',
+    BUY,
+    provider
+  )
+  console.log('[Uniswap] Expected xKNCb qty for 100 KNC:', expectedQty)
+  t.true(Number(expectedQty) > 0)
 })
 
 test('Get Uniswap Portfolio of xKNCa', async (t) => {

--- a/src/types/xToken.d.ts
+++ b/src/types/xToken.d.ts
@@ -96,3 +96,8 @@ export interface IReturn {
   expectedQuantity: string
   source: Exchange
 }
+
+export interface IReturns {
+  best: IReturn
+  estimates: Array<IReturn>
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6967,10 +6967,10 @@ xtend@~4.0.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
-xtoken-abis@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/xtoken-abis/-/xtoken-abis-0.1.7.tgz#229fc6c59bc42615b8869090d5c09a96c9949008"
-  integrity sha512-4X6zVpsht4s5tYt2b0wJoKopdABAvBhlt2GCCyBeU9PGfMCoBhCAH5X+d6pu4BEiLf75nyRpXdUpP91V7wKaVA==
+xtoken-abis@0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/xtoken-abis/-/xtoken-abis-0.1.8.tgz#7f6fe00ee8c3542d999fe338cdf15172f8cbc779"
+  integrity sha512-OmDqmDIobPpoLCZQ14Pgxv2qESycK05k8SjHB81wL8alBbmBoE5SCInqwIBnCi/7MoocF9utiIfPtiXUbyHklQ==
 
 y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [x] Added helper method to estimate returns for xKNC Uniswap pool
- [x] Deprecated `getExpectedQuantityOnBalancer` in favor of `getBestReturns`